### PR TITLE
Check client DUID in prvDHCPv6_handleOption.

### DIFF
--- a/source/FreeRTOS_BitConfig.c
+++ b/source/FreeRTOS_BitConfig.c
@@ -49,8 +49,8 @@
  * @brief Initialise a bit-config struct.
  *
  * @param[in] pxConfig: The structure containing a copy of the bits.
- * @param[in] uxSize: The length of the binary data stream.
  * @param[in] pucData: Not NULL if a bit-stream must be analysed, otherwise NULL.
+ * @param[in] uxSize: The length of the binary data stream.
  *
  * @return pdTRUE if the malloc was OK, otherwise pdFALSE.
  */
@@ -88,11 +88,11 @@ BaseType_t xBitConfig_init( BitConfig_t * pxConfig,
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Initialise a bit-config struct.
+ * @brief Read from a bit-config struct.
  *
  * @param[in] pxConfig: The structure containing a copy of the bits.
- * @param[in] uxSize: The length of the binary data stream.
  * @param[in] pucData: Not NULL if a bit-stream must be analysed, otherwise NULL.
+ * @param[in] uxSize: The length of the binary data stream.
  *
  * @return pdTRUE if the malloc was OK, otherwise pdFALSE.
  */
@@ -128,6 +128,40 @@ BaseType_t xBitConfig_read_uc( BitConfig_t * pxConfig,
     return xResult;
 }
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief Peek the last byte from a bit-config struct.
+ *
+ * @param[in] pxConfig: The structure containing a copy of the bits.
+ * @param[in] pucData: The buffer to stored peeked data.
+ * @param[in] uxSize: The length of the binary data stream.
+ *
+ * @return pdTRUE if the malloc was OK, otherwise pdFALSE.
+ */
+BaseType_t pucBitConfig_peek_last_index_uc( BitConfig_t * pxConfig,
+                                            uint8_t * pucData,
+                                            size_t uxSize )
+{
+    BaseType_t xResult = pdFALSE;
+    const size_t uxNeeded = uxSize;
+
+    if( pxConfig->xHasError == pdFALSE )
+    {
+        if( ( pxConfig->uxIndex >= uxNeeded ) && ( pucData != NULL ) )
+        {
+            ( void ) memcpy( pucData, &( pxConfig->ucContents[ pxConfig->uxIndex - uxNeeded ] ), uxNeeded );
+
+            xResult = pdTRUE;
+        }
+        else
+        {
+            /* Not support to peek length larger than write. */
+            pxConfig->xHasError = pdTRUE;
+        }
+    }
+
+    return xResult;
+}
 
 /**
  * @brief Read a byte from the bit stream.

--- a/source/FreeRTOS_DHCPv6.c
+++ b/source/FreeRTOS_DHCPv6.c
@@ -1185,6 +1185,11 @@ static BaseType_t prvDHCPv6_handleOption( struct xNetworkEndPoint * pxEndPoint,
 
                if( uxIDSize <= sizeof( pxDHCPMessage->xClientID.pucID ) )
                {
+                   /* Refer to RFC3315 - sec 15.3, we need to discard packets with following conditions:
+                    *  - the message does not include a Server Identifier option.
+                    *  - the message does not include a Client Identifier option.
+                    *  - the contents of the Client Identifier option does not match the client's DUID.
+                    *  - the "transaction-id" field value does not match the value the client used in its Solicit message. */
                    ( void ) xBitConfig_read_uc( pxMessage, pxDHCPMessage->xClientID.pucID, uxIDSize ); /* Link Layer address, 6 bytes */
 
                    /* Check client DUID. */
@@ -1335,12 +1340,6 @@ static BaseType_t prvDHCPv6Analyse( struct xNetworkEndPoint * pxEndPoint,
         switch( pxDHCPMessage->uxMessageType )
         {
             case DHCPv6_message_Type_Advertise:
-
-            /* Refer to RFC3315 - sec 15.3, we need to discard packets with following conditions:
-             *  - the message does not include a Server Identifier option.
-             *  - the message does not include a Client Identifier option.
-             *  - the contents of the Client Identifier option does not match the client's DUID.
-             *  - the "transaction-id" field value does not match the value the client used in its Solicit message. */
             case DHCPv6_message_Type_Confirm:
             case DHCPv6_message_Type_Reply:
             case DHCPv6_message_Type_Decline:

--- a/source/FreeRTOS_DNS_Parser.c
+++ b/source/FreeRTOS_DNS_Parser.c
@@ -1155,7 +1155,7 @@
                  * is a real problem, like data corruption. */
                 configASSERT( pxNetworkBuffer != NULL );
 
-                condifASSERT( pxNetworkBuffer->pxEndPoint != NULL )
+                configASSERT( pxNetworkBuffer->pxEndPoint != NULL );
                 ( void ) memcpy( &xEndPoint, pxNetworkBuffer->pxEndPoint, sizeof( xEndPoint ) );
 
                 /* NBNS only handles IPv4 or "A" records. */

--- a/source/include/FreeRTOS_BitConfig.h
+++ b/source/include/FreeRTOS_BitConfig.h
@@ -58,6 +58,9 @@
     BaseType_t xBitConfig_read_uc( BitConfig_t * pxConfig,
                                    uint8_t * pucData,
                                    size_t uxSize );
+    BaseType_t pucBitConfig_peek_last_index_uc( BitConfig_t * pxConfig,
+                                                uint8_t * pucData,
+                                                size_t uxSize );
 
     void vBitConfig_write_8( BitConfig_t * pxConfig,
                              uint8_t ucValue );

--- a/source/include/FreeRTOS_DHCP.h
+++ b/source/include/FreeRTOS_DHCP.h
@@ -65,6 +65,8 @@
     #define dhcpINITIAL_DHCP_TX_PERIOD    ( pdMS_TO_TICKS( 5000U ) )
 #endif
 
+#define dhcpIPv6_CLIENT_DUID_LENGTH                ( 14U )
+
 /* Codes of interest found in the DHCP options field. */
 #define dhcpIPv4_ZERO_PAD_OPTION_CODE              ( 0U )      /**< Used to pad other options to make them aligned. See RFC 2132. */
 #define dhcpIPv4_SUBNET_MASK_OPTION_CODE           ( 1U )      /**< Subnet mask. See RFC 2132. */
@@ -210,6 +212,8 @@ struct xDHCP_DATA
     eDHCPState_t eDHCPState;       /**< The current state of the DHCP state machine. */
     eDHCPState_t eExpectedState;   /**< If the state is not equal the the expected state, no cycle needs to be done. */
     Socket_t xDHCPSocket;
+    /**< Record lastest client ID for DHCPv6. */
+    uint8_t ucClientDUID[ dhcpIPv6_CLIENT_DUID_LENGTH ];
 };
 
 typedef struct xDHCP_DATA DHCPData_t;


### PR DESCRIPTION
<!--- Title -->
Check client DUID in prvDHCPv6_handleOption.

Description
-----------
<!--- Describe your changes in detail. -->
Refer to RFC3315 - sec 15.3, we need to discard packets with following conditions:
  - the message does not include a Server Identifier option.
  - the message does not include a Client Identifier option.
  - the contents of the Client Identifier option does not match the client's DUID.
  - the "transaction-id" field value does not match the value the client used in its Solicit message.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Run test case DHCPv6/005.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
